### PR TITLE
Added the management of the shared IP in the configuration of pacemaker.

### DIFF
--- a/lamamos/rex/lib/init.pm
+++ b/lamamos/rex/lib/init.pm
@@ -19,7 +19,17 @@ sub initialise{
 
   communication::waitOtherServ('test', 1);
 
+  #Launching of pacemaker
   installBaseSysteme();
+
+  Service::pacemaker::primitive::define({
+
+    'primitive_name' => 'p_ip',
+    'primitive_class' => 'ocf',
+    'provided_by' => 'heartbeat',
+    'primitive_type' => 'IPaddr2',
+    'parameters' => {'ip' => '192.168.56.100', 'cidr_netmask'=>'24', 'nic'=>'eth0',},
+  });
 }
 
 


### PR DESCRIPTION
... Close #2.

It also can be used to define the primary server. Close #13.
